### PR TITLE
feat/rhf components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,12 +8,16 @@
       "name": "rireki",
       "version": "0.0.0",
       "dependencies": {
+        "@hookform/error-message": "^2.0.1",
+        "@hookform/resolvers": "^3.10.0",
         "@tanstack/react-query": "^5.64.1",
         "axios": "^1.7.9",
+        "classnames": "^2.5.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-hook-form": "^7.54.2",
-        "react-router": "^7.1.1"
+        "react-router": "^7.1.1",
+        "zod": "^3.24.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.17.0",
@@ -861,6 +865,26 @@
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@hookform/error-message": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@hookform/error-message/-/error-message-2.0.1.tgz",
+      "integrity": "sha512-U410sAr92xgxT1idlu9WWOVjndxLdgPUHEB8Schr27C9eh7/xUnITWpCMF93s+lGiG++D4JnbSnrb5A21AdSNg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0",
+        "react-hook-form": "^7.0.0"
+      }
+    },
+    "node_modules/@hookform/resolvers": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-3.10.0.tgz",
+      "integrity": "sha512-79Dv+3mDF7i+2ajj7SkypSKHhl1cbln1OGavqrsF7p6mbUv11xpqpacPsGDCTRvCSjEEIez2ef1NveSVL3b0Ag==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react-hook-form": "^7.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -2290,6 +2314,12 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "license": "MIT"
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -5721,6 +5751,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.24.1",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.1.tgz",
+      "integrity": "sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -11,12 +11,16 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@hookform/error-message": "^2.0.1",
+    "@hookform/resolvers": "^3.10.0",
     "@tanstack/react-query": "^5.64.1",
     "axios": "^1.7.9",
+    "classnames": "^2.5.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.54.2",
-    "react-router": "^7.1.1"
+    "react-router": "^7.1.1",
+    "zod": "^3.24.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",

--- a/src/components/forms/FormInput.tsx
+++ b/src/components/forms/FormInput.tsx
@@ -1,0 +1,60 @@
+import {
+  Path,
+  UseFormRegister,
+  FieldValues,
+  DeepMap,
+  FieldError,
+} from "react-hook-form";
+import { ErrorMessage } from "@hookform/error-message";
+import { Input, InputProps } from "./Input";
+
+export type FormInputProps<TFormValues extends FieldValues> = {
+  name: Path<TFormValues>;
+  outerDivClassName?: string;
+  innerDivClassName?: string;
+  inputClassName?: string;
+  register?: UseFormRegister<TFormValues>;
+  errors?: Partial<DeepMap<TFormValues, FieldError>>;
+  isErrorMessageDisplayed?: boolean; // use ONLY in cases where there are no error messages possible, or you want to display all of a form's errors away from individual inputs
+} & Omit<InputProps, "name">;
+
+const FormInput = <TFormValues extends FieldValues>({
+  outerDivClassName,
+  innerDivClassName,
+  inputClassName,
+  name,
+  label,
+  register,
+  errors,
+  isErrorMessageDisplayed = true,
+  ...props
+}: FormInputProps<TFormValues>): JSX.Element => {
+  return (
+    <div className={outerDivClassName}>
+      <div className={innerDivClassName}>
+        <label htmlFor={name} className="text-xs">
+          {label}
+          {props.required && "*"}
+        </label>
+        <Input
+          name={name}
+          label={label}
+          className={inputClassName}
+          {...props}
+          {...(register && register(name))}
+        />
+      </div>
+      {isErrorMessageDisplayed && (
+        <ErrorMessage
+          errors={errors}
+          name={name as any}
+          render={({ message }) => (
+            <p className="text-xs text-red-500">{message}</p>
+          )}
+        />
+      )}
+    </div>
+  );
+};
+
+export default FormInput;

--- a/src/components/forms/FormSelect.tsx
+++ b/src/components/forms/FormSelect.tsx
@@ -1,0 +1,62 @@
+import {
+  Path,
+  UseFormRegister,
+  FieldValues,
+  DeepMap,
+  FieldError,
+} from "react-hook-form";
+import { Select, SelectProps } from "./Select";
+import { ErrorMessage } from "@hookform/error-message";
+
+export type FormSelectProps<TFormValues extends FieldValues> = {
+  name: Path<TFormValues>;
+  outerDivClassName?: string;
+  innerDivClassName?: string;
+  selectClassName?: string;
+  register?: UseFormRegister<TFormValues>;
+  errors?: Partial<DeepMap<TFormValues, FieldError>>;
+  isErrorMessageDisplayed?: boolean; // use ONLY in cases where there are no error messages possible, or you want to display all of a form's errors away from individual inputs
+} & Omit<SelectProps, "name">;
+
+const FormSelect = <TFormValues extends FieldValues>({
+  outerDivClassName,
+  innerDivClassName,
+  selectClassName,
+  name,
+  label,
+  register,
+  errors,
+  isErrorMessageDisplayed = true,
+  ...props
+}: FormSelectProps<TFormValues>): JSX.Element => {
+  return (
+    <div className={outerDivClassName}>
+      <div className={innerDivClassName}>
+        <label htmlFor={name} className="text-xs">
+          {label}
+          {props.required && "*"}
+        </label>
+        <Select
+          name={name}
+          label={label}
+          className={selectClassName}
+          {...props}
+          {...(register && register(name))}
+        >
+          {props.children}
+        </Select>
+      </div>
+      {isErrorMessageDisplayed && (
+        <ErrorMessage
+          errors={errors}
+          name={name as any}
+          render={({ message }) => (
+            <p className="text-xs text-red-500">{message}</p>
+          )}
+        />
+      )}
+    </div>
+  );
+};
+
+export default FormSelect;

--- a/src/components/forms/Input.tsx
+++ b/src/components/forms/Input.tsx
@@ -1,0 +1,45 @@
+import { forwardRef, DetailedHTMLProps, InputHTMLAttributes } from "react";
+import classNames from "classnames";
+
+export type InputType =
+  | "text"
+  | "email"
+  | "date"
+  | "time"
+  | "datetime"
+  | "number";
+
+export type InputProps = {
+  id: string;
+  name: string;
+  label: string;
+  type?: InputType;
+  className?: string;
+  placeholder?: string;
+} & DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement>;
+
+export const Input: React.FC<InputProps> = forwardRef<
+  HTMLInputElement,
+  InputProps
+>(
+  (
+    { id, name, label, type = "text", className = "", placeholder, ...props },
+    ref,
+  ) => {
+    return (
+      <input
+        id={id}
+        ref={ref}
+        name={name}
+        type={type}
+        aria-label={label}
+        placeholder={placeholder}
+        className={classNames(
+          "block w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 placeholder-gray-400 transition",
+          className,
+        )}
+        {...props}
+      />
+    );
+  },
+);

--- a/src/components/forms/Select.tsx
+++ b/src/components/forms/Select.tsx
@@ -1,0 +1,33 @@
+import { forwardRef, DetailedHTMLProps, SelectHTMLAttributes } from "react";
+import classNames from "classnames";
+
+export type SelectProps = {
+  id: string;
+  name: string;
+  label: string;
+  className?: string;
+} & DetailedHTMLProps<
+  SelectHTMLAttributes<HTMLSelectElement>,
+  HTMLSelectElement
+>;
+
+export const Select: React.FC<SelectProps> = forwardRef<
+  HTMLSelectElement,
+  SelectProps
+>(({ id, name, label, className = "", ...props }, ref) => {
+  return (
+    <select
+      id={id}
+      ref={ref}
+      name={name}
+      aria-label={label}
+      className={classNames(
+        "block w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 transition",
+        className,
+      )}
+      {...props}
+    >
+      {props.children}
+    </select>
+  );
+});

--- a/src/components/forms/index.ts
+++ b/src/components/forms/index.ts
@@ -1,0 +1,2 @@
+export { default as FormInput } from "./FormInput";
+export { default as FormSelect } from "./FormSelect";


### PR DESCRIPTION
## Changes

The following react-hook-form compatible components are now available, along with their generic versions that don't require RHF:

- `FormInput`
- `FormSelect`